### PR TITLE
Specify Redis connection URL in CI

### DIFF
--- a/.github/workflows/cacheTest.yml
+++ b/.github/workflows/cacheTest.yml
@@ -1,8 +1,7 @@
 name: Test Prisma Extension
 
 on:
-  push:
-    branches: [ "main" ]
+  push
 
 jobs:
   test_cache:
@@ -39,3 +38,5 @@ jobs:
 
     - name: Run Prisma Extension tests
       run: node --test
+      env:
+        REDIS_CONNECTION_URL: "redis://redis"


### PR DESCRIPTION
The GitHub Actions continuous integration workflow now explicitly specifies the Redis connection URL during tests.

Continuous integration now runs on pushes to any branch.