### PR TITLE
Explicitly specify registry URL in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -86,6 +86,7 @@ jobs:
       - name: Setup NodeJS version ${{ env.node-version }}
         uses: actions/setup-node@v4
         with:
+          registry-url: "https://registry.npmjs.org/"
           node-version: ${{ env.node-version }}
           cache: "npm"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-redis-cache",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "Gabriel434",
   "description": "Streamlines caching Prisma operations using Redis with strong type-safety.",
   "keywords": [


### PR DESCRIPTION
The Continuous Integration workflow for publishing the npm package now explicitly specifies the registry URL to fix authentication issues.