### PR TITLE
Make current directory explicit in package files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-redis-cache",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": "Gabriel434",
   "description": "Streamlines caching Prisma operations using Redis with strong type-safety.",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     ".": "./dist/src/index.js"
   },
   "files": [
-    "dist/src/**/*"
+    "./dist/src/**/*"
   ],
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
The files field of the package file now references to the dist directory using a explicit local path.