### PR TITLE
Specify built extension artifact download path

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -68,6 +68,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: dist
+          path: dist
 
       - name: Run Prisma Extension tests
         run: node --test
@@ -94,6 +95,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: dist
+          path: dist
 
       - name: Publish Prisma Extension
         run: npm publish

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-redis-cache",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "author": "Gabriel434",
   "description": "Streamlines caching Prisma operations using Redis with strong type-safety.",
   "keywords": [


### PR DESCRIPTION
The download path for the built extension is now correctly specified, fixing npm publication using Continuous Integration.

Fixes #13