### PR TITLE
Removed non-standard profiling API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,4 +27,4 @@ function configureCache(config: ExtensionConfig) {
 
 export default configureCache
 
-export {CacheEventListeners, ExtensionConfig} from "./RedisCache.js"
+export {ExtensionConfig} from "./RedisCache.js"

--- a/tests/prisma.ts
+++ b/tests/prisma.ts
@@ -1,27 +1,11 @@
 import {PrismaClient} from "@prisma/client"
 import configureCache from "../src/index.js"
-import {CacheEventListeners} from "../src/RedisCache.js"
 import redis from "./redis.js"
 
-const eventListeners: CacheEventListeners<DOMHighResTimeStamp> = {
-    start() {
-        return performance.now()
-    },
-    readEnd(start, type) {
-        console.log(`Cache ${type} on ${calcElapsed(start)}ms`)
-    },
-    writeEnd(start, type) {
-        console.log(`Cache ${type} on ${calcElapsed(start)}ms`)
-    }
-}, prisma = new PrismaClient().$extends(
+const prisma = new PrismaClient().$extends(
     configureCache({
-        redisClient: redis,
-        eventListeners
+        redisClient: redis
     })
 )
-
-function calcElapsed(profiler: number) {
-    return performance.now() - profiler
-}
 
 export default prisma


### PR DESCRIPTION
The profiling API using custom methods was removed in favor of an implementation using open standards like OpenTelemetry.